### PR TITLE
fix mistake in conf example of file node

### DIFF
--- a/any-sync/configuration.md
+++ b/any-sync/configuration.md
@@ -104,7 +104,7 @@ These options are specific for Any-Sync File nodes.
 ```yaml
 # required; S3 configuration
 s3Store:
-  endpoints:  # optional; endpoint for S3-compatible object storage
+  endpoint:  # optional; endpoint for S3-compatible object storage
   region:     # required; S3 region name
   profile:    # required; S3 profile name
   bucket:     # required; S3 bucket name


### PR DESCRIPTION
### Description
the endpoints key should be endpoint according to the definition of the configuration datastructure in
https://github.com/anyproto/any-sync-filenode/blob/6a19cc112a17a24419e6de7b79f533f7e3eb081e/store/s3store/config.go#L11

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
NA

### Mobile & Desktop Screenshots/Recordings
NA

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed
